### PR TITLE
Return false for repoExists when 301 is returned

### DIFF
--- a/src/main/scala/uk/gov/hmrc/initrepository/Github.scala
+++ b/src/main/scala/uk/gov/hmrc/initrepository/Github.scala
@@ -106,6 +106,7 @@ trait Github {
 
     req.execute().flatMap { res => res.status match {
       case 200 => Future.successful(true)
+      case 301 => Future.successful(false)
       case 404 => Future.successful(false)
       case _   => Future.failed(new RequestException(req, res))
     }}


### PR DESCRIPTION
* This stops the job failing when specifying a name that used to exist, but has been renamed since