### PR TITLE
Add npm files to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,5 +15,3 @@ dist
 /RUNNING_PID
 /.settings
 *.iws
-node_modules/
-npm-debug.log

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@ dist
 /RUNNING_PID
 /.settings
 *.iws
+node_modules/
+npm-debug.log

--- a/src/main/scala/uk/gov/hmrc/initrepository/git/LocalGitService.scala
+++ b/src/main/scala/uk/gov/hmrc/initrepository/git/LocalGitService.scala
@@ -94,6 +94,8 @@ class LocalGitService(git: LocalGitStore) {
       |*.iws
       |node_modules/
       |npm-debug.log
+      |yarn-debug.log
+      |yarn-error.log
       |
     """.stripMargin
   }

--- a/src/main/scala/uk/gov/hmrc/initrepository/git/LocalGitService.scala
+++ b/src/main/scala/uk/gov/hmrc/initrepository/git/LocalGitService.scala
@@ -92,6 +92,8 @@ class LocalGitService(git: LocalGitStore) {
       |/RUNNING_PID
       |/.settings
       |*.iws
+      |node_modules/
+      |npm-debug.log
       |
     """.stripMargin
   }


### PR DESCRIPTION
As a result of creating a new prototype, the `node_modules` directory was being checked in.

This leads to a higher chance of getting a 503 when deploying to the prototype environment due to hitting a limit on the amount of files an elastic beanstalk instance can cope with.